### PR TITLE
Fix pfifgw script for packet loss tracking

### DIFF
--- a/plugins/telegraf_pfifgw.php
+++ b/plugins/telegraf_pfifgw.php
@@ -91,12 +91,13 @@ foreach ($gw_array as $gw => $gateway) {
     $delay = $gw_statuses[$gw]["delay"];
     $stddev = $gw_statuses[$gw]["stddev"];
     $status = $gw_statuses[$gw]["status"];
+    $loss = $gw_statuses[$gw]["loss"];
 
     $interface = $gateway["interface"];
     $gwdescr = $gateway["descr"];
     $monitor = $gateway["monitor"];
     $source = $gateway["gateway"];
-    $loss = $gateway["loss"];
+    
     if (!isset($monitor)) {
         $monitor = "Unavailable";
     }


### PR DESCRIPTION
This PR updates the pfifgw script to correctly extract packet loss metrics for Gateways.
I have tested this on an running OPNSense and was able to verify that these metrics are now exporting as expected.
On merge, fixes #32